### PR TITLE
Limit mockito dependency to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,9 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
To do not pollute production classpath. Also changed mockito-all to mockito-core

Explanation why:
https://solidsoft.wordpress.com/2012/09/11/beyond-the-mockito-refcard-part-3-mockito-core-vs-mockito-all-in-mavengradle-based-projects/